### PR TITLE
Allow null clear color to disable clearing screen

### DIFF
--- a/src/main/java/de/eskalon/commons/screen/ManagedScreen.java
+++ b/src/main/java/de/eskalon/commons/screen/ManagedScreen.java
@@ -15,6 +15,8 @@
 
 package de.eskalon.commons.screen;
 
+import javax.annotation.Nullable;
+
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.InputProcessor;
@@ -22,7 +24,6 @@ import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.viewport.Viewport;
 
 import de.eskalon.commons.core.ManagedGame;
@@ -215,9 +216,9 @@ public abstract class ManagedScreen implements Screen {
 
 	/**
 	 * @return the color to clear the screen with before the rendering is
-	 *         started, or null to not clear the screen
+	 *         started, or {@code null} to not clear the screen
 	 */
-	public @Null Color getClearColor() {
+	public @Nullable Color getClearColor() {
 		return Color.BLACK;
 	}
 

--- a/src/main/java/de/eskalon/commons/screen/ManagedScreen.java
+++ b/src/main/java/de/eskalon/commons/screen/ManagedScreen.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.viewport.Viewport;
 
 import de.eskalon.commons.core.ManagedGame;
@@ -214,9 +215,9 @@ public abstract class ManagedScreen implements Screen {
 
 	/**
 	 * @return the color to clear the screen with before the rendering is
-	 *         started
+	 *         started, or null to not clear the screen
 	 */
-	public Color getClearColor() {
+	public @Null Color getClearColor() {
 		return Color.BLACK;
 	}
 

--- a/src/main/java/de/eskalon/commons/screen/ScreenManager.java
+++ b/src/main/java/de/eskalon/commons/screen/ScreenManager.java
@@ -298,13 +298,15 @@ public class ScreenManager<S extends ManagedScreen, T extends ScreenTransition>
 				render(delta); // render again so no frame is skipped
 			} else {
 				/* Render the current screen; no transition is going on */
-				ScreenUtils.clear(currScreen.getClearColor(), true);
+				if (currScreen.getClearColor() != null)
+					ScreenUtils.clear(currScreen.getClearColor(), true);
 				this.currScreen.render(delta);
 			}
 		} else {
 			if (!this.transition.isDone()) {
 				/* Render the current transition */
-				ScreenUtils.clear(this.transition.getClearColor(), true);
+				if (this.transition.getClearColor() != null)
+					ScreenUtils.clear(this.transition.getClearColor(), true);
 				this.transition.render(delta,
 						ScreenFboUtils.screenToTexture(this.lastScreen,
 								this.lastFBO, delta),

--- a/src/main/java/de/eskalon/commons/screen/transition/ScreenTransition.java
+++ b/src/main/java/de/eskalon/commons/screen/transition/ScreenTransition.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.utils.Disposable;
 
+import com.badlogic.gdx.utils.Null;
 import de.eskalon.commons.screen.ManagedScreen;
 import de.eskalon.commons.screen.ScreenManager;
 
@@ -115,9 +116,9 @@ public abstract class ScreenTransition implements Disposable {
 
 	/**
 	 * @return the color to clear the screen with before the rendering is
-	 *         started
+	 *         started, or null to not clear the screen
 	 */
-	public Color getClearColor() {
+	public @Null Color getClearColor() {
 		return Color.BLACK;
 	}
 

--- a/src/main/java/de/eskalon/commons/screen/transition/ScreenTransition.java
+++ b/src/main/java/de/eskalon/commons/screen/transition/ScreenTransition.java
@@ -15,12 +15,13 @@
 
 package de.eskalon.commons.screen.transition;
 
+import javax.annotation.Nullable;
+
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.utils.Disposable;
 
-import com.badlogic.gdx.utils.Null;
 import de.eskalon.commons.screen.ManagedScreen;
 import de.eskalon.commons.screen.ScreenManager;
 
@@ -116,9 +117,9 @@ public abstract class ScreenTransition implements Disposable {
 
 	/**
 	 * @return the color to clear the screen with before the rendering is
-	 *         started, or null to not clear the screen
+	 *         started, or {@code null} to not clear the screen
 	 */
-	public @Null Color getClearColor() {
+	public @Nullable Color getClearColor() {
 		return Color.BLACK;
 	}
 

--- a/src/main/java/de/eskalon/commons/utils/ScreenFboUtils.java
+++ b/src/main/java/de/eskalon/commons/utils/ScreenFboUtils.java
@@ -49,7 +49,8 @@ public class ScreenFboUtils {
 	public static TextureRegion screenToTexture(ManagedScreen screen,
 			FrameBuffer fbo, float delta) {
 		fbo.begin();
-		ScreenUtils.clear(screen.getClearColor(), true);
+		if (screen.getClearColor() != null)
+			ScreenUtils.clear(screen.getClearColor(), true);
 		screen.render(delta);
 		fbo.end();
 


### PR DESCRIPTION
There may be a better way of going about this, but it's what I'm doing. Tested on desktop and GWT.

Clearing the screen can harm frame rates slightly (relative to how complex your scene is to render) on Intel integrated graphics (especially when not also clearing the depth buffer?), so in cases where the areas not drawn to are static I prefer not to clear it. When using a proper graphics card, it doesn't seem to make much difference.

<details>
<summary>Click for fun facts for when drawing directly to the screen buffer (not really relevant to this pull request)</summary>

* On GWT, you don't need to clear. Not unless `config.preserveDrawingBuffer = true`, maybe (haven't tested it; don't see much of a need to).
* If only clearing on resize, such as for games that have pillarboxing, it's good to clear in `render()` a couple times due to double buffering.
* For some games, it may be a good idea to clear anyway (such as in case the player ends up out of bounds and is subjected to it flickering between buffers).

</details>



